### PR TITLE
Update to zig v0.14.0 / Fix bug that caused the assertion in `Quadtree.add_value` to fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache
+.zig-cache
 zig-out

--- a/build.zig
+++ b/build.zig
@@ -16,16 +16,16 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const lib = b.addStaticLibrary(.{
-        .name = "Quadtree",
+        .name = "quadtree",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = b.path("src/quadtree.zig"),
+        .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    _ = b.addModule("Quadtree", .{
-        .root_source_file = b.path("src/quadtree.zig"),
+    _ = b.addModule("quadtree", .{
+        .root_source_file = b.path("src/root.zig"),
     });
 
     // This declares intent for the library to be installed into the standard

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "Quadtree",
+    .name = .quadtree,
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.1",
@@ -7,7 +7,9 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.14.0",
+
+    .fingerprint = 0x82e83d5923e22202,
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -58,13 +58,10 @@
         // better to explicitly list the files and directories instead, to insure that
         // fetching from tarballs, file system paths, and version control all result
         // in the same contents hash.
-        "buid.zig",
+        "build.zig",
         "build.zig.zon",
         "LICENSE",
         "README.md",
-        "src/quadtree.zig",
-        "src/box.zig",
-        "src/vector2.zig",
-        "src/test.zig",
+        "src",
     },
 }

--- a/src/box.zig
+++ b/src/box.zig
@@ -44,8 +44,8 @@ pub fn Box(comptime T: type) type {
 
         pub fn getCenter(self: *const Self) Vector2 {
             return v.Vector2(T){
-                .x = (self.left + self.width) / 2,
-                .y = (self.top + self.height) / 2,
+                .x = self.left + self.width / 2,
+                .y = self.top + self.height / 2,
             };
         }
 

--- a/src/quadtree.zig
+++ b/src/quadtree.zig
@@ -756,3 +756,34 @@ test "quadtree add remove and find all intersections" {
 
     try test_quadtree_add_remove_and_find_all_intersections(1000);
 }
+
+// This test shows how the bug in `Box.getCenter` will cause the quadtree to try
+// to add new values into the wrong quadrant after the first subdivision.
+test "quadtree should add values into correct subdivided quadtrants" {
+    const TestQuadtree = Quadtree(*const test_node, f32, void);
+
+    const ally = std.testing.allocator;
+    const dimensions = b.Box(f32){ .left = 0, .top = 0, .width = 200, .height = 200 };
+    var quadtree = try TestQuadtree.init(ally, {}, dimensions, test_GetBox, test_Equal);
+    defer quadtree.deinit();
+
+    // Make sure to spawn Threshold + 1 boxes to force the quadtree to subdivide.
+    const node_count = TestQuadtree.Threshold + 1;
+    var nodes: [node_count]test_node = undefined;
+
+    const node_size = 10;
+    for (0..node_count) |i| {
+        nodes[i] = test_node{
+            .id = i + 1,
+            .box = b.Box(f32){
+                // Boxes must spawn in the top-left corner of the bottom right
+                // quadrant for the error to occur.
+                .left = 100,
+                .top = 100,
+                .width = node_size,
+                .height = node_size,
+            },
+        };
+        quadtree.add(&nodes[i]) catch unreachable;
+    }
+}

--- a/src/quadtree.zig
+++ b/src/quadtree.zig
@@ -29,7 +29,7 @@ pub fn Quadtree(comptime T: type, comptime UnitType: type, comptime Context: typ
 
         pub const ValuePair = struct { T, T };
 
-        const Node = struct {
+        pub const Node = struct {
             children: [4]?*Node = .{ null, null, null, null },
             values: std.ArrayListUnmanaged(T),
             box: Box,

--- a/src/quadtree.zig
+++ b/src/quadtree.zig
@@ -433,7 +433,7 @@ fn test_valuePair_less_than(
 
 //std::vector<Node> generateRandomNodes(std::size_t n)
 fn generateRandomNodes(n: usize, allocator: std.mem.Allocator) !std.ArrayList(test_node) {
-    var generator = std.rand.DefaultPrng.init(0); //TODO seed
+    var generator = std.Random.DefaultPrng.init(0);
     //const originDistribution = generator.random().
     //auto generator = std::default_random_engine();
     //auto originDistribution = std::uniform_real_distribution(0.0f, 1.0f);
@@ -455,7 +455,7 @@ fn generateRandomNodes(n: usize, allocator: std.mem.Allocator) !std.ArrayList(te
 }
 
 fn generateRandomRemoved(n: usize, allocator: std.mem.Allocator) !std.ArrayList(bool) {
-    var generator = std.rand.DefaultPrng.init(0); //TODO seed
+    var generator = std.Random.DefaultPrng.init(0); //TODO seed
     var removed = std.ArrayList(bool).init(allocator);
     try removed.resize(n);
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,10 +1,3 @@
-const std = @import("std");
-const testing = std.testing;
-
-export fn add(a: i32, b: i32) i32 {
-    return a + b;
-}
-
-test "basic add functionality" {
-    try testing.expect(add(3, 7) == 10);
-}
+pub const Quadtree = @import("quadtree.zig").Quadtree;
+pub const Box = @import("box.zig").Box;
+pub const Vector2 = @import("vector2.zig").Vector2;


### PR DESCRIPTION
Hi,

this PR mainly contains:
- update to zig 0.14.0
- fix `build.zig.zon` to add `build.zig` correctly to paths (previous typo prevented the library from being used in other projects)
- fix bug in `Box.getCenter` that caused the assertion in `Quadtree.add_value` to fail

Best regards
Stefan